### PR TITLE
Add VSCode focus delay after hard refresh

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,7 @@ const getScriptGeneric = ( options: Options ): string => {
       delay ${options.delay}
       key code 15 using {command down ${options.force ? ', shift down' : ''}} # ⌘R/⇧⌘R
     end tell
+    delay 0.125
     ${options.focus ? '' : `tell application "${app}" to activate`}
   `;
 


### PR DESCRIPTION
Without this added delay, the latest version of macOS (Sequoia 15.0.1), is causing rapid flicking focus between the browser and VSCode when doing a hard refresh. The delay fixes this issue.

Note: I didn't use `delay ${options.delay}` because that controls the delay from when the browser is focused to when the keystroke is sent to the browser.